### PR TITLE
Adding pipeline structure preview from declared MR sequences

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,9 @@ import os
 import sys
 import logging
 import traceback
-from raidionicsrads.compute import run_rads
+import json
+from raidionicsrads.Utils.configuration_parser import ResourcesConfiguration
+from raidionicsrads.compute import run_rads, preview_pipeline
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 
@@ -36,8 +38,16 @@ def main(argv):
         print('usage: main.py -c <config_filepath> (--Verbose <mode>)')
         sys.exit()
 
+    ResourcesConfiguration.getInstance().set_environment(config_path=config_filename)
+
     try:
-        run_rads(config_filename=config_filename)
+        if ResourcesConfiguration.getInstance().sequences_declaration_filename:
+            with open(ResourcesConfiguration.getInstance().sequences_declaration_filename, 'r') as infile:
+                sequences_declaration = json.load(infile)
+            preview_pipeline(config_filename=config_filename, sequences_declaration=sequences_declaration)
+
+        else:
+            run_rads(config_filename=config_filename)
     except Exception as e:
         logging.error('{}'.format(traceback.format_exc()))
 

--- a/raidionicsrads/Pipelines/FeaturesComputationStep.py
+++ b/raidionicsrads/Pipelines/FeaturesComputationStep.py
@@ -69,6 +69,10 @@ class FeaturesComputationStep(AbstractPipelineStep):
 
         """
         try:
+            if self.skip:
+                logging.info(f"Features computation step not executed since marked as skippable.")
+                return self._patient_parameters
+
             if ResourcesConfiguration.getInstance().diagnosis_task == 'neuro_diagnosis':
                 self.__run_neuro_reporting()
             else:

--- a/raidionicsrads/Pipelines/PipelineStructure.py
+++ b/raidionicsrads/Pipelines/PipelineStructure.py
@@ -106,6 +106,16 @@ class Pipeline:
             else:
                 logging.warning(f"Step dismissed because task could not be matched.")
 
+    def mark_sequence_as_known(self) -> None:
+        """
+        Marks the Classification step(s) as skippable, to be used when the patient's MR
+        sequences are already known ahead of time (e.g., declared rather than detected),
+        so that setup() does not attempt to run the actual sequence classification model.
+        """
+        for s in list(self._steps.keys()):
+            if self._steps[s].get_task() == str(TaskType.Class):
+                self._steps[s].skip = True
+
     def setup(self, patient_parameters) -> None:
         """
         @TODO. Should not consider all classification tasks the same, the initial exception is only for the sequence

--- a/raidionicsrads/Pipelines/SurgicalReportingStep.py
+++ b/raidionicsrads/Pipelines/SurgicalReportingStep.py
@@ -45,6 +45,10 @@ class SurgicalReportingStep(AbstractPipelineStep):
 
     def execute(self):
         try:
+            if self.skip:
+                logging.info(f"Surgical reporting step not executed since marked as skippable.")
+                return self._patient_parameters
+
             if ResourcesConfiguration.getInstance().diagnosis_task == 'neuro_diagnosis':
                 self.__run_neuro_surgical_reporting()
             else:

--- a/raidionicsrads/Utils/DataStructures/PatientStructure.py
+++ b/raidionicsrads/Utils/DataStructures/PatientStructure.py
@@ -23,12 +23,16 @@ class PatientParameters:
     _registrations = {}  # All registration transforms.
     _reportings = {}  # All clinical reports (if applicable).
 
-    def __init__(self, id: str, patient_filepath: str):
+    def __init__(self, id: str, patient_filepath: str = None, declared_sequences: dict = None):
         """
         """
         self.__reset()
         self._unique_id = id
         self._input_filepath = patient_filepath
+
+        if declared_sequences:
+            self.__init_from_declared_sequences(declared_sequences)
+            return
 
         if not patient_filepath or not os.path.exists(patient_filepath):
             # Error case
@@ -73,6 +77,25 @@ class PatientParameters:
     @property
     def reportings(self) -> dict:
         return self._reportings
+
+    def __init_from_declared_sequences(self, sequences_per_timestamp: dict):
+        """
+        Populates the patient from a declared set of MR sequences, without reading or
+        requiring any real image file on disk. Used for pipeline structure preview.
+
+        Parameters
+        ----------
+        sequences_per_timestamp: dict
+            e.g. {"T0": ["T1-CE"], "T1": ["T1-CE", "T1-w", "FLAIR"]}
+        """
+        for timestamp_uid, sequences in sequences_per_timestamp.items():
+            self._timestamps[timestamp_uid] = TimestampParameters(id=timestamp_uid, timestamp_filepath="")
+
+            for sequence in sequences:
+                data_uid = f"{timestamp_uid}_{sequence}"
+                volume = RadiologicalVolume(uid=data_uid, input_filename=f"{sequence}.nii.gz", timestamp_uid=timestamp_uid)
+                volume.set_sequence_type(sequence)
+                self.radiological_volumes[data_uid] = volume
 
     def __init_from_scratch(self):
         """

--- a/raidionicsrads/Utils/configuration_parser.py
+++ b/raidionicsrads/Utils/configuration_parser.py
@@ -61,6 +61,7 @@ class ResourcesConfiguration:
         self.output_folder = None
         self.model_folder = None
         self.pipeline_filename = None
+        self.sequences_declaration_filename = None
 
         # Parameters matching the main_config parameters from the raidionics_seg backend
         self.predictions_overlapping_ratio = 0.
@@ -489,6 +490,10 @@ class ResourcesConfiguration:
         if self.config.has_option('System', 'pipeline_filename'):
             if self.config['System']['pipeline_filename'].split('#')[0].strip() != '':
                 self.pipeline_filename = self.config['System']['pipeline_filename'].split('#')[0].strip()
+
+        if self.config.has_option('System', 'sequences_declaration_filename'):
+            if self.config['System']['sequences_declaration_filename'].split('#')[0].strip() != '':
+                self.sequences_declaration_filename = self.config['System']['sequences_declaration_filename'].split('#')[0].strip()
 
     def __parse_runtime_parameters(self):
         if self.config.has_option('Runtime', 'overlapping_ratio'):

--- a/raidionicsrads/compute.py
+++ b/raidionicsrads/compute.py
@@ -2,6 +2,8 @@ from .Utils.configuration_parser import ResourcesConfiguration
 import time
 import traceback
 import logging
+import os
+import json
 from .Utils.DataStructures.PatientStructure import PatientParameters
 from .Pipelines.PipelineStructure import Pipeline
 from .Pipelines.ClassificationStep import ClassificationStep
@@ -91,7 +93,7 @@ def run_folder_inspection(config_filename: str, logging_filename: str = None) ->
     # patient_parameters if running another real pipeline straight after.
     logging.info('Total elapsed time for executing the pipeline: {} seconds.'.format(time.time() - start))
 
-def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_filename: str = None) -> None:
+def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_filename: str = None) -> bool:
     """
     Builds executed_pipeline.json for a given pipeline.json and a declared set of MR
     sequences, without running classification or any actual inference.
@@ -101,12 +103,18 @@ def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_
         logging.basicConfig(filename=logging_filename, filemode='a', format="%(asctime)s ; %(name)s ; %(levelname)s ; %(message)s", datefmt='%d/%m/%Y %H.%M')
         logging.getLogger().setLevel(logging.DEBUG)
 
+    executed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline.json")
+    existing_pipeline = None
+    if os.path.exists(executed_pipeline_fn):
+        with open(executed_pipeline_fn, 'r') as infile:
+            existing_pipeline = json.load(infile)
+
     try:
         patient_parameters = PatientParameters(id="Patient", declared_sequences=sequences_declaration)
     except Exception as e:
         logging.error("""[Backend error] Patient data setup phase of failed with:\n{}""".format(e))
         logging.debug("Traceback: {}.".format(traceback.format_exc()))
-        return
+        return False
 
     logging.info("Starting pipeline preview for file: {}.".format(ResourcesConfiguration.getInstance().pipeline_filename))
     start = time.time()
@@ -117,6 +125,12 @@ def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_
     except Exception as e:
         logging.error("""[Backend error] Pipeline preview setup phase failed with:\n{}""".format(e))
         logging.debug("Traceback: {}.".format(traceback.format_exc()))
-        return
+        return False
     logging.info('Total elapsed time for building the pipeline preview: {} seconds.'.format(time.time() - start))
 
+    with open(executed_pipeline_fn, 'r') as infile:
+        new_pipeline = json.load(infile)
+
+    already_computed = existing_pipeline is not None and new_pipeline == existing_pipeline
+    logging.info("Pipeline already fully computed: {}.".format(already_computed))
+    return already_computed

--- a/raidionicsrads/compute.py
+++ b/raidionicsrads/compute.py
@@ -4,7 +4,10 @@ import traceback
 import logging
 import os
 import json
+import numpy as np
 from .Utils.DataStructures.PatientStructure import PatientParameters
+from .Utils.DataStructures.AnnotationStructure import Annotation, AnnotationClassType
+from .Utils.utilities import get_type_from_enum_name
 from .Pipelines.PipelineStructure import Pipeline
 from .Pipelines.ClassificationStep import ClassificationStep
 
@@ -25,6 +28,13 @@ def run_rads(config_filename: str, logging_filename: str = None) -> None:
         logger.setLevel(logging.DEBUG)
         logger.addHandler(handler)
 
+    executed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline.json")
+    completed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline_completed.json")
+    existing_pipeline = None
+    if os.path.exists(completed_pipeline_fn):
+        with open(completed_pipeline_fn, 'r') as infile:
+            existing_pipeline = json.load(infile)
+
     logging.info("Starting pipeline for file: {}.".format(ResourcesConfiguration.getInstance().pipeline_filename))
     start = time.time()
     pip = Pipeline(ResourcesConfiguration.getInstance().pipeline_filename)
@@ -41,8 +51,17 @@ def run_rads(config_filename: str, logging_filename: str = None) -> None:
         logging.error("""[Backend error] Patient data setup phase for models in automatic selection failed with:\n{}""".format(e))
         logging.debug("Traceback: {}.".format(traceback.format_exc()))
         return
+
+    with open(executed_pipeline_fn, 'r') as infile:
+        new_pipeline = json.load(infile)
+    steps_computed = _steps_already_computed(new_pipeline, existing_pipeline)
+    _apply_step_skip_decisions(pip, new_pipeline, steps_computed, patient_parameters)
+    logging.info("Steps already computed: {}/{}.".format(sum(steps_computed.values()), len(steps_computed)))
+    
     try:
         patient_parameters = pip.execute(patient_parameters=patient_parameters)
+        with open(completed_pipeline_fn, 'w', newline='\n') as outfile:
+            json.dump(new_pipeline, outfile, indent=4)
         pip.cleanup()
     except Exception as e:
         logging.error("""[Backend error] Patient data execution phase of failed with:\n{}""".format(e))
@@ -103,10 +122,10 @@ def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_
         logging.basicConfig(filename=logging_filename, filemode='a', format="%(asctime)s ; %(name)s ; %(levelname)s ; %(message)s", datefmt='%d/%m/%Y %H.%M')
         logging.getLogger().setLevel(logging.DEBUG)
 
-    executed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline.json")
+    completed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline_completed.json")
     existing_pipeline = None
-    if os.path.exists(executed_pipeline_fn):
-        with open(executed_pipeline_fn, 'r') as infile:
+    if os.path.exists(completed_pipeline_fn):
+        with open(completed_pipeline_fn, 'r') as infile:
             existing_pipeline = json.load(infile)
 
     try:
@@ -128,9 +147,103 @@ def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_
         return False
     logging.info('Total elapsed time for building the pipeline preview: {} seconds.'.format(time.time() - start))
 
+    executed_pipeline_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "executed_pipeline.json")
     with open(executed_pipeline_fn, 'r') as infile:
         new_pipeline = json.load(infile)
-
-    already_computed = existing_pipeline is not None and new_pipeline == existing_pipeline
+    steps_computed = _steps_already_computed(new_pipeline, existing_pipeline)
+    already_computed = all(steps_computed.values())
+    logging.info("Steps already computed: {}/{}.".format(sum(steps_computed.values()), len(steps_computed)))
     logging.info("Pipeline already fully computed: {}.".format(already_computed))
     return already_computed
+
+def _step_signature(step: dict) -> str:
+    return json.dumps(step, sort_keys=True)
+
+def _steps_already_computed(new_pipeline: dict, existing_pipeline: dict) -> dict:
+    """
+    For each step in the new plan, checks whether an identical step (matched by full
+    content, not by key position) already exists somewhere in a previous run's plan.
+    """
+    if existing_pipeline is None:
+        return {k: False for k in new_pipeline}
+    existing_signatures = {_step_signature(v) for v in existing_pipeline.values()}
+    return {k: _step_signature(v) in existing_signatures for k, v in new_pipeline.items()}
+
+def _reload_existing_segmentation(step: dict, patient_parameters) -> bool:
+    """
+    For a Segmentation step already covered by a previous run, reconstructs the annotation
+    filename it would have written (same convention as SegmentationStep) and, if found on
+    disk, registers it into patient_parameters so downstream steps (e.g. Segmentation
+    refinement) can find it without recomputing.
+    """
+    input_json = step["inputs"]["0"]
+    volume_uid = patient_parameters.get_radiological_volume_uid(timestamp=input_json["timestamp"], sequence=input_json["sequence"])
+
+    if volume_uid == "-1":
+        return False
+    volume  = patient_parameters.get_radiological_volume(volume_uid)
+
+    for target in step["target"]:
+        annotation_class = get_type_from_enum_name(AnnotationClassType, target)
+        if annotation_class == -1:
+            return False
+        if len(patient_parameters.get_all_annotations_uids_class_radiological_volume(volume_uid=volume_uid, annotation_class=annotation_class)) > 0:
+            continue # already registered, e.g. by an earlier step in this same run
+
+        anno_fn = os.path.join(volume.output_folder, os.path.basename(volume.raw_input_filepath).split('.')[0] + '_annotation-' + target + '_' + step["model"].split('/')[0] + '.nii.gz')
+
+        if not os.path.exists(anno_fn):
+            return False
+
+        non_available_uid = True
+        anno_uid = None
+        while non_available_uid:
+            anno_uid = 'A' + str(np.random.randint(0, 10000))
+            if anno_uid not in patient_parameters.get_all_annotations_uids():
+                non_available_uid = False
+
+        annotation = Annotation(uid=anno_uid, input_filename=anno_fn, output_folder=volume.output_folder, radiological_volume_uid=volume_uid, annotation_class=target)
+        patient_parameters.include_annotation(anno_uid, annotation)
+    return True
+
+def _apply_step_skip_decisions(pip, new_pipeline: dict, steps_computed: dict, patient_parameters) -> None:
+    """
+    For each step already covered by a previous run, attempts to reload its expected existing
+    output into patient_parameters so downstream steps still find their input, and only then
+    marks it skippable. Steps whose output can't be reloaded are left to run for real, which
+    is always safe.
+    """
+    for step_key in sorted(new_pipeline.keys(), key=int):
+        if not steps_computed.get(step_key) or step_key not in pip._steps:
+            continue
+        step_json = new_pipeline[step_key]
+        task = step_json.get("task")
+        step_obj = pip._steps[step_key]
+
+        if task == "Classification":
+            continue  # always re-run for real; required to assign sequence types
+
+        elif task == "Segmentation":
+            if _reload_existing_segmentation(step_json, patient_parameters):
+                step_obj.skip = True
+
+        elif task == "Segmentation refinement":
+            input_json = step_json["inputs"]["0"]
+            volume_uid = patient_parameters.get_radiological_volume_uid(timestamp=input_json["timestamp"],
+                                                                         sequence=input_json["sequence"])
+            annotation_class = get_type_from_enum_name(AnnotationClassType, input_json["labels"]) if input_json.get("labels") else -1
+            if volume_uid != "-1" and annotation_class != -1 and len(
+                    patient_parameters.get_all_annotations_uids_class_radiological_volume(
+                        volume_uid=volume_uid, annotation_class=annotation_class)) > 0:
+                step_obj.skip = True
+
+        elif task == "Features computation":
+            report_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "reporting", "T" + str(step_json["timestamp"]), "neuro_clinical_report.json")
+            if os.path.exists(report_fn):
+                step_obj.skip = True
+
+        elif task == "Surgical reporting":
+            report_fn = os.path.join(ResourcesConfiguration.getInstance().output_folder, "reporting", "neuro_surgical_report.json")
+            if os.path.exists(report_fn):
+                step_obj.skip = True
+                

--- a/raidionicsrads/compute.py
+++ b/raidionicsrads/compute.py
@@ -90,3 +90,33 @@ def run_folder_inspection(config_filename: str, logging_filename: str = None) ->
     # @TODO. Should dump it differently, or arrange filenames for re-use in Raidionics, or return the updated
     # patient_parameters if running another real pipeline straight after.
     logging.info('Total elapsed time for executing the pipeline: {} seconds.'.format(time.time() - start))
+
+def preview_pipeline(config_filename: str, sequences_declaration: dict, logging_filename: str = None) -> None:
+    """
+    Builds executed_pipeline.json for a given pipeline.json and a declared set of MR
+    sequences, without running classification or any actual inference.
+    """
+    ResourcesConfiguration.getInstance().set_environment(config_path=config_filename)
+    if logging_filename:
+        logging.basicConfig(filename=logging_filename, filemode='a', format="%(asctime)s ; %(name)s ; %(levelname)s ; %(message)s", datefmt='%d/%m/%Y %H.%M')
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    try:
+        patient_parameters = PatientParameters(id="Patient", declared_sequences=sequences_declaration)
+    except Exception as e:
+        logging.error("""[Backend error] Patient data setup phase of failed with:\n{}""".format(e))
+        logging.debug("Traceback: {}.".format(traceback.format_exc()))
+        return
+
+    logging.info("Starting pipeline preview for file: {}.".format(ResourcesConfiguration.getInstance().pipeline_filename))
+    start = time.time()
+    try:
+        pip = Pipeline(ResourcesConfiguration.getInstance().pipeline_filename)
+        pip.mark_sequence_as_known()
+        pip.setup(patient_parameters=patient_parameters)
+    except Exception as e:
+        logging.error("""[Backend error] Pipeline preview setup phase failed with:\n{}""".format(e))
+        logging.debug("Traceback: {}.".format(traceback.format_exc()))
+        return
+    logging.info('Total elapsed time for building the pipeline preview: {} seconds.'.format(time.time() - start))
+


### PR DESCRIPTION
## Adding pipeline structure preview from declared MR sequences
Introduces a way to build executed_pipeline.json from a declared set of MR sequences instead of real patient data, for a quick overview of all pipeline steps and their expected outputs without running classification or inference.
- PatientParameters: new declared_sequences constructor path, bypassing disk scanning
- Pipeline: mark_sequence_as_known() to skip classification when sequences are known
- compute.py: new preview_pipeline() entry point
- configuration_parser.py: new sequences_declaration_filename config field
- main.py: automatically runs the preview when the config declares sequences_declaration_filename

## Adding per-step output reuse to run_rads and preview_pipeline
Compares the freshly resolved pipeline plan against executed_pipeline_completed.json (written only after a real run finishes successfully, not by preview) to decide which steps can be skipped. Segmentation results are reloaded into patient_parameters so downstream steps (e.g. Segmentation refinement) still find their input; reporting steps are skipped based on the existence of their fixed-path output files. Registration and Apply registration are not covered yet and always run for real.